### PR TITLE
Fix voxel dose storage for ROI > 2 GBytes.

### DIFF
--- a/MC-GPU_v1.3.cu
+++ b/MC-GPU_v1.3.cu
@@ -465,7 +465,7 @@ int main(int argc, char **argv)
                                               //  (3) inverse Rayleigh mean free path (divided by density, cm^2/g)
   short int dose_ROI_x_min, dose_ROI_x_max, dose_ROI_y_min, dose_ROI_y_max, dose_ROI_z_min, dose_ROI_z_max;  // Coordinates of the dose region of interest (ROI)
   ulonglong2 *voxels_Edep = NULL;           // Poiter where the voxel energy deposition array will be allocated
-  int voxels_Edep_bytes = 0;                      // Size of the voxel Edep array
+  unsigned int voxels_Edep_bytes = 0;                      // Size of the voxel Edep array
   
   ulonglong2 materials_dose[MAX_MATERIALS];    // Array for tally_materials_dose.     !!tally_materials_dose!!
   int kk;
@@ -1243,7 +1243,7 @@ int main(int argc, char **argv)
 //!       @param[out] file_name_materials
 //!       @param[out] file_name_output
 ////////////////////////////////////////////////////////////////////////////////
-void read_input(int argc, char** argv, int myID, unsigned long long int* total_histories, int* seed_input, int* gpu_id, int* num_threads_per_block, int* histories_per_thread, struct detector_struct* detector_data, unsigned long long int** image_ptr, int* image_bytes, struct source_struct* source_data, struct source_energy_struct* source_energy_data, char* file_name_voxels, char file_name_materials[MAX_MATERIALS][250] , char* file_name_output, char* file_name_espc, int* num_projections, double* D_angle, double* angularROI_0, double* angularROI_1, double* initial_angle, ulonglong2** voxels_Edep_ptr, int* voxels_Edep_bytes, char* file_dose_output, short int* dose_ROI_x_min, short int* dose_ROI_x_max, short int* dose_ROI_y_min, short int* dose_ROI_y_max, short int* dose_ROI_z_min, short int* dose_ROI_z_max, double* SRotAxisD, double* vertical_translation_per_projection, int* flag_material_dose)
+void read_input(int argc, char** argv, int myID, unsigned long long int* total_histories, int* seed_input, int* gpu_id, int* num_threads_per_block, int* histories_per_thread, struct detector_struct* detector_data, unsigned long long int** image_ptr, int* image_bytes, struct source_struct* source_data, struct source_energy_struct* source_energy_data, char* file_name_voxels, char file_name_materials[MAX_MATERIALS][250] , char* file_name_output, char* file_name_espc, int* num_projections, double* D_angle, double* angularROI_0, double* angularROI_1, double* initial_angle, ulonglong2** voxels_Edep_ptr, unsigned int* voxels_Edep_bytes, char* file_dose_output, short int* dose_ROI_x_min, short int* dose_ROI_x_max, short int* dose_ROI_y_min, short int* dose_ROI_y_max, short int* dose_ROI_z_min, short int* dose_ROI_z_max, double* SRotAxisD, double* vertical_translation_per_projection, int* flag_material_dose)
 {
   FILE* file_ptr = NULL;
   char new_line[250];
@@ -2395,7 +2395,7 @@ void init_CUDA_device( int* gpu_id, int myID, int numprocs,
         struct rayleigh_struct* rayleigh_table, struct rayleigh_struct** rayleigh_table_device,
         struct compton_struct* compton_table, struct compton_struct** compton_table_device, 
         struct detector_struct** detector_data_device, struct source_struct** source_data_device,
-        ulonglong2* voxels_Edep, ulonglong2** voxels_Edep_device, int voxels_Edep_bytes, short int* dose_ROI_x_min, short int* dose_ROI_x_max, short int* dose_ROI_y_min, short int* dose_ROI_y_max, short int* dose_ROI_z_min, short int* dose_ROI_z_max,
+        ulonglong2* voxels_Edep, ulonglong2** voxels_Edep_device, unsigned int voxels_Edep_bytes, short int* dose_ROI_x_min, short int* dose_ROI_x_max, short int* dose_ROI_y_min, short int* dose_ROI_y_max, short int* dose_ROI_z_min, short int* dose_ROI_z_max,
         ulonglong2* materials_dose, ulonglong2** materials_dose_device, int flag_material_dose, int num_projections)
 {    
   cudaDeviceProp deviceProp;

--- a/MC-GPU_v1.3.h
+++ b/MC-GPU_v1.3.h
@@ -264,7 +264,7 @@ rayleigh_struct
 
 //// *** HOST FUNCTIONS *** ////
 
-void read_input(int argc, char** argv, int myID, unsigned long long int* total_histories, int* gpu_id, int* seed_input, int* num_threads_per_block, int* histories_per_thread, struct detector_struct* detector_data, unsigned long long int** image_ptr, int* image_bytes, struct source_struct* source_data, struct source_energy_struct* source_energy_data, char* file_name_voxels, char file_name_materials[MAX_MATERIALS][250], char* file_name_output, char* file_name_espc, int* num_projections, double* D_angle, double* angularROI_0, double* angularROI_1, double* initial_angle, ulonglong2** voxels_Edep_ptr, int* voxels_Edep_bytes, char* file_dose_output, short int* dose_ROI_x_min, short int* dose_ROI_x_max, short int* dose_ROI_y_min, short int* dose_ROI_y_max, short int* dose_ROI_z_min, short int* dose_ROI_z_max, double* SRotAxisD, double* vertical_translation_per_projection, int* flag_material_dose);
+void read_input(int argc, char** argv, int myID, unsigned long long int* total_histories, int* gpu_id, int* seed_input, int* num_threads_per_block, int* histories_per_thread, struct detector_struct* detector_data, unsigned long long int** image_ptr, int* image_bytes, struct source_struct* source_data, struct source_energy_struct* source_energy_data, char* file_name_voxels, char file_name_materials[MAX_MATERIALS][250], char* file_name_output, char* file_name_espc, int* num_projections, double* D_angle, double* angularROI_0, double* angularROI_1, double* initial_angle, ulonglong2** voxels_Edep_ptr, unsigned int* voxels_Edep_bytes, char* file_dose_output, short int* dose_ROI_x_min, short int* dose_ROI_x_max, short int* dose_ROI_y_min, short int* dose_ROI_y_max, short int* dose_ROI_z_min, short int* dose_ROI_z_max, double* SRotAxisD, double* vertical_translation_per_projection, int* flag_material_dose);
 void load_voxels(int myID, char* file_name_voxels, float* density_max, struct voxel_struct* voxel_data, float2** voxel_mat_dens_ptr, unsigned int* voxel_mat_dens_bytes, short int* dose_ROI_x_max, short int* dose_ROI_y_max, short int* dose_ROI_z_max);
 void load_material(int myID, char file_name_materials[MAX_MATERIALS][250], float* density_max, float* density_nominal, struct linear_interp* mfp_table_data, float2** mfp_Woodcock_table, int* mfp_Woodcock_table_bytes, float3** mfp_table_a_ptr, float3** mfp_table_b_ptr, int* mfp_table_bytes, struct rayleigh_struct *rayleigh_table_ptr, struct compton_struct *compton_table_ptr);
 void trim_name(char* input_line, char* file_name);
@@ -294,7 +294,7 @@ void init_CUDA_device( int* gpu_id, int myID, int numprocs,
         struct rayleigh_struct* rayleigh_table, struct rayleigh_struct** rayleigh_table_device,
         struct compton_struct* compton_table, struct compton_struct** compton_table_device,
         struct detector_struct** detector_data_device, struct source_struct** source_data_device,
-        ulonglong2* voxels_Edep, ulonglong2** voxels_Edep_device, int voxels_Edep_bytes, short int* dose_ROI_x_min, short int* dose_ROI_x_max, short int* dose_ROI_y_min, short int* dose_ROI_y_max, short int* dose_ROI_z_min, short int* dose_ROI_z_max,
+        ulonglong2* voxels_Edep, ulonglong2** voxels_Edep_device, unsigned int voxels_Edep_bytes, short int* dose_ROI_x_min, short int* dose_ROI_x_max, short int* dose_ROI_y_min, short int* dose_ROI_y_max, short int* dose_ROI_z_min, short int* dose_ROI_z_max,
         ulonglong2* materials_dose, ulonglong2** materials_dose_device, int flag_material_dose, int num_projections);
 #endif
 


### PR DESCRIPTION
For voxel dose tally, current code stores the # of bytes of Edep array in `int` type. It overflows and results in a negative number if the ROI requires > 2 GBytes memory to store the dose information.

Here I modified `int` to `unsigned int` so that it supports up to 4 GBytes, following existing `voxel_mat_dens_bytes`'s definition.

<img width="865" alt="pic1" src="https://github.com/DIDSR/MCGPU/assets/30524126/1ebcd475-b00d-4c0b-846f-714c3d15fe30">
